### PR TITLE
Extract URL de-slashing logic to UriCleaner Service and fix query parameter handling - update tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TYPO3: [ '13.4', '14.0' ]
+        TYPO3: [ '13.4', '14.3' ]
         PHP: [ '8.2', '8.3', '8.4', '8.5' ]
-      exclude:
-        - TYPO3: '14.0'
-          PHP: '8.2'
+        exclude:
+          - TYPO3: '14.3'
+            PHP: '8.2'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up PHP Version ${{ matrix.PHP }}
         uses: shivammathur/setup-php@v2
@@ -36,7 +36,7 @@ jobs:
         run: composer validate
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.composer/cache
           key: dependencies-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,24 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '56 5 * * *'
 
 jobs:
   testsuite:
 
-    runs-on: ubuntu-latest
+    name: all tests
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
-        TYPO3: [ 12.4, 13.4]
-        PHP: [ 8.2, 8.3 ]
+        TYPO3: [ '13.4', '14.0' ]
+        PHP: [ '8.2', '8.3', '8.4', '8.5' ]
+      exclude:
+        - TYPO3: '14.0'
+          PHP: '8.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: .Build/bin/phpstan analyze -c Build/phpstan.neon
       - name: Phpcsfix
         run: .Build/bin/php-cs-fixer fix --config=Build/php-cs-fixer.php --dry-run --stop-on-violation --using-cache=no
+      - name: Unit Tests
+        run: .Build/bin/phpunit Tests/Unit
       - name: Functional Tests
         run: |
           export typo3DatabaseName="typo3";

--- a/Classes/DeSlashCanonicalUrl.php
+++ b/Classes/DeSlashCanonicalUrl.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace B13\DeSlash;
 
+use B13\DeSlash\Service\UriCleaner;
 use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
 
 /**
@@ -19,12 +20,14 @@ use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
  */
 class DeSlashCanonicalUrl
 {
+    public function __construct(private readonly UriCleaner $uriCleaner) {}
+
     public function __invoke(ModifyUrlForCanonicalTagEvent $event): void
     {
         $url = $event->getUrl();
-        if (str_ends_with($url, '/')) {
-            $url = rtrim($url, '/');
-            $event->setUrl($url);
+        $newUrl = $this->uriCleaner->removeTrailingSlashFromPath($url);
+        if ($newUrl !== $url) {
+            $event->setUrl($newUrl);
         }
     }
 }

--- a/Classes/DeSlashHrefLangGenerator.php
+++ b/Classes/DeSlashHrefLangGenerator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace B13\DeSlash;
 
+use B13\DeSlash\Service\UriCleaner;
 use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
 
 /**
@@ -19,13 +20,13 @@ use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
  */
 class DeSlashHrefLangGenerator
 {
+    public function __construct(private readonly UriCleaner $uriCleaner) {}
+
     public function __invoke(ModifyHrefLangTagsEvent $event): void
     {
         $hrefLangs = $event->getHrefLangs();
         foreach ($hrefLangs as $key => $hrefLang) {
-            if (str_ends_with($hrefLang, '/')) {
-                $hrefLangs[$key] = rtrim($hrefLang, '/');
-            }
+            $hrefLangs[$key] = $this->uriCleaner->removeTrailingSlashFromPath($hrefLang);
         }
         $event->setHrefLangs($hrefLangs);
     }

--- a/Classes/DeSlashingPageLinkBuilder.php
+++ b/Classes/DeSlashingPageLinkBuilder.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace B13\DeSlash;
 
+use B13\DeSlash\Service\UriCleaner;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Frontend\Event\AfterLinkIsGeneratedEvent;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
@@ -21,6 +22,8 @@ use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
  */
 final class DeSlashingPageLinkBuilder
 {
+    public function __construct(private readonly UriCleaner $uriCleaner) {}
+
     public function __invoke(AfterLinkIsGeneratedEvent $event): void
     {
         /** @var LinkResultInterface $linkResult */
@@ -28,9 +31,16 @@ final class DeSlashingPageLinkBuilder
         if ($linkResult->getUrl() === '/') {
             return;
         }
-        if ($linkResult->getType() === LinkService::TYPE_PAGE && str_ends_with($linkResult->getUrl(), '/')) {
-            $linkResult = $linkResult->withAttribute('href', rtrim($linkResult->getUrl(), '/'));
-            $event->setLinkResult($linkResult);
+        if ($linkResult->getType() === LinkService::TYPE_PAGE) {
+            $url = $linkResult->getUrl();
+            $newUrl = $this->uriCleaner->removeTrailingSlashFromPath($url);
+            if ($newUrl !== $url) {
+                // Note: LinkResultInterface does not provide a withUrl() or equivalent method to update the internal URL.
+                // Downstream code calling LinkResult::getUrl() will still receive the old URL.
+                // We update the 'href' attribute which is used when rendering the actual HTML anchor tag.
+                $linkResult = $linkResult->withAttribute('href', $newUrl);
+                $event->setLinkResult($linkResult);
+            }
         }
     }
 }

--- a/Classes/Service/UriCleaner.php
+++ b/Classes/Service/UriCleaner.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "de_slash" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\DeSlash\Service;
+
+class UriCleaner
+{
+    /**
+     * Remove trailing slash from the path segment of a URL, preserving query parameters and fragments.
+     * Returns the modified URL, or the original if no trailing slash in path.
+     */
+    public function removeTrailingSlashFromPath(string $url): string
+    {
+        if ($url === '') {
+            return $url;
+        }
+
+        $parts = parse_url($url);
+        if (empty($parts['path']) || trim($parts['path'], '/') === '' || !str_ends_with($parts['path'], '/')) {
+            return $url;
+        }
+
+        $newPath = rtrim($parts['path'], '/');
+        $newUrl = isset($parts['scheme']) ? $parts['scheme'] . '://' : (str_starts_with($url, '//') ? '//' : '');
+        if (isset($parts['user'])) {
+            $newUrl .= $parts['user'];
+            if (isset($parts['pass'])) {
+                $newUrl .= ':' . $parts['pass'];
+            }
+            $newUrl .= '@';
+        }
+        $newUrl .= $parts['host'] ?? '';
+        if (isset($parts['port'])) {
+            $newUrl .= ':' . $parts['port'];
+        }
+        $newUrl .= $newPath;
+        if (isset($parts['query'])) {
+            $newUrl .= '?' . $parts['query'];
+        }
+        if (isset($parts['fragment'])) {
+            $newUrl .= '#' . $parts['fragment'];
+        }
+
+        return $newUrl;
+    }
+}

--- a/Classes/Service/UriCleaner.php
+++ b/Classes/Service/UriCleaner.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace B13\DeSlash\Service;
 
+use TYPO3\CMS\Core\Http\Uri;
+
 class UriCleaner
 {
     /**
@@ -24,32 +26,19 @@ class UriCleaner
             return $url;
         }
 
-        $parts = parse_url($url);
-        if (empty($parts['path']) || trim($parts['path'], '/') === '' || !str_ends_with($parts['path'], '/')) {
+        try {
+            $uri = new Uri($url);
+        } catch (\InvalidArgumentException $e) {
+            // Malformed URL according to PSR-7 (e.g. '///'), return as is
             return $url;
         }
 
-        $newPath = rtrim($parts['path'], '/');
-        $newUrl = isset($parts['scheme']) ? $parts['scheme'] . '://' : (str_starts_with($url, '//') ? '//' : '');
-        if (isset($parts['user'])) {
-            $newUrl .= $parts['user'];
-            if (isset($parts['pass'])) {
-                $newUrl .= ':' . $parts['pass'];
-            }
-            $newUrl .= '@';
-        }
-        $newUrl .= $parts['host'] ?? '';
-        if (isset($parts['port'])) {
-            $newUrl .= ':' . $parts['port'];
-        }
-        $newUrl .= $newPath;
-        if (isset($parts['query'])) {
-            $newUrl .= '?' . $parts['query'];
-        }
-        if (isset($parts['fragment'])) {
-            $newUrl .= '#' . $parts['fragment'];
+        $path = $uri->getPath();
+
+        if ($path === '' || trim($path, '/') === '' || !str_ends_with($path, '/')) {
+            return $url;
         }
 
-        return $newUrl;
+        return (string)$uri->withPath(rtrim($path, '/'));
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,23 +4,24 @@ With TYPO3, it is possible to have a trailing slash in your URLs,
 but also without them - depending on the use-case.
 
 By default, TYPO3 does not have a trailing slash at the end of
-each URL, but there are some technical limitations, why it e.g.
-happens on the home page, where there is always a trailing slash.
+each URL, but there are some technical limitations which, for example,
+cause it to happen on the home page where there is always a trailing slash.
 
-You can configure an ending like ".html" or "/" for each URL,
-and have more enhancers for plugins.
+You can configure a suffix like `.html` or `/` for each URL,
+and have additional enhancers for plugins.
 
-This extension works in a naive way to remove trailing slashes
-from
+This extension works in a straightforward way to remove trailing slashes
+from:
 
 * All generated links
-* All your canonical URLs
+* All canonical URLs
+* HrefLang tags
 
-It even redirects incoming URLs with a trailing slash into the same page without.
+It even redirects incoming URLs with a trailing slash to the same URL without one.
 
 ## Configuration
 
-Install the extension, ensure that all your site configuration base's for languages do NOT have a trailing slash
+Install the extension and ensure that all your site configuration bases for languages do NOT have a trailing slash.
 
 Good: `base: 'https://example.com/en'`
 Bad: `base: 'https://example.com/en/'`
@@ -32,7 +33,7 @@ That's it.
 
 ## Caveats
 
-* Ensure that you do not have a enhancer or PageType decorator that creates URLs (also for plugins) with a trailing slash.
+* Ensure that you do not have an enhancer or PageType decorator that creates URLs (also for plugins) with a trailing slash.
 
 * Redirects will only work on GET or HEAD requests.
 

--- a/Tests/Unit/DeSlashCanonicalUrlTest.php
+++ b/Tests/Unit/DeSlashCanonicalUrlTest.php
@@ -24,7 +24,7 @@ class DeSlashCanonicalUrlTest extends TestCase
     public function testInvokeCleansUrlWhenTrailingSlashIsPresent(): void
     {
         $event = new ModifyUrlForCanonicalTagEvent(
-            $this->createStub(ServerRequestInterface::class),
+            self::createStub(ServerRequestInterface::class),
             new Page([]),
             'https://example.com/en/',
             null
@@ -45,7 +45,7 @@ class DeSlashCanonicalUrlTest extends TestCase
     public function testInvokeDoesNotSetUrlWhenNoTrailingSlash(): void
     {
         $event = new ModifyUrlForCanonicalTagEvent(
-            $this->createStub(ServerRequestInterface::class),
+            self::createStub(ServerRequestInterface::class),
             new Page([]),
             'https://example.com/en',
             null

--- a/Tests/Unit/DeSlashCanonicalUrlTest.php
+++ b/Tests/Unit/DeSlashCanonicalUrlTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "de_slash" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\DeSlash\Tests\Unit;
+
+use B13\DeSlash\DeSlashCanonicalUrl;
+use B13\DeSlash\Service\UriCleaner;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Domain\Page;
+use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
+
+class DeSlashCanonicalUrlTest extends TestCase
+{
+    public function testInvokeCleansUrlWhenTrailingSlashIsPresent(): void
+    {
+        $event = new ModifyUrlForCanonicalTagEvent(
+            $this->createStub(ServerRequestInterface::class),
+            new Page([]),
+            'https://example.com/en/',
+            null
+        );
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::once())
+            ->method('removeTrailingSlashFromPath')
+            ->with('https://example.com/en/')
+            ->willReturn('https://example.com/en');
+
+        $listener = new DeSlashCanonicalUrl($uriCleaner);
+        $listener($event);
+
+        self::assertSame('https://example.com/en', $event->getUrl());
+    }
+
+    public function testInvokeDoesNotSetUrlWhenNoTrailingSlash(): void
+    {
+        $event = new ModifyUrlForCanonicalTagEvent(
+            $this->createStub(ServerRequestInterface::class),
+            new Page([]),
+            'https://example.com/en',
+            null
+        );
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::once())
+            ->method('removeTrailingSlashFromPath')
+            ->with('https://example.com/en')
+            ->willReturn('https://example.com/en');
+
+        $listener = new DeSlashCanonicalUrl($uriCleaner);
+        $listener($event);
+
+        self::assertSame('https://example.com/en', $event->getUrl());
+    }
+}

--- a/Tests/Unit/DeSlashHrefLangGeneratorTest.php
+++ b/Tests/Unit/DeSlashHrefLangGeneratorTest.php
@@ -27,7 +27,7 @@ class DeSlashHrefLangGeneratorTest extends TestCase
             'de-DE' => 'https://example.com/de',
         ];
 
-        $event = new ModifyHrefLangTagsEvent($this->createStub(ServerRequestInterface::class));
+        $event = new ModifyHrefLangTagsEvent(self::createStub(ServerRequestInterface::class));
         $event->setHrefLangs($hrefLangs);
 
         $uriCleaner = $this->createMock(UriCleaner::class);

--- a/Tests/Unit/DeSlashHrefLangGeneratorTest.php
+++ b/Tests/Unit/DeSlashHrefLangGeneratorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "de_slash" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\DeSlash\Tests\Unit;
+
+use B13\DeSlash\DeSlashHrefLangGenerator;
+use B13\DeSlash\Service\UriCleaner;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
+
+class DeSlashHrefLangGeneratorTest extends TestCase
+{
+    public function testInvokeCleansHrefLangUrls(): void
+    {
+        $hrefLangs = [
+            'en-US' => 'https://example.com/en/',
+            'de-DE' => 'https://example.com/de',
+        ];
+
+        $event = new ModifyHrefLangTagsEvent($this->createStub(ServerRequestInterface::class));
+        $event->setHrefLangs($hrefLangs);
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::exactly(2))
+            ->method('removeTrailingSlashFromPath')
+            ->willReturnMap([
+                ['https://example.com/en/', 'https://example.com/en'],
+                ['https://example.com/de', 'https://example.com/de'],
+            ]);
+
+        $listener = new DeSlashHrefLangGenerator($uriCleaner);
+        $listener($event);
+
+        self::assertSame([
+            'en-US' => 'https://example.com/en',
+            'de-DE' => 'https://example.com/de',
+        ], $event->getHrefLangs());
+    }
+}

--- a/Tests/Unit/DeSlashingPageLinkBuilderTest.php
+++ b/Tests/Unit/DeSlashingPageLinkBuilderTest.php
@@ -28,7 +28,7 @@ class DeSlashingPageLinkBuilderTest extends TestCase
         $linkResult->method('getUrl')->willReturn('/en/');
         $linkResult->method('getType')->willReturn(LinkService::TYPE_PAGE);
 
-        $modifiedLinkResult = $this->createStub(LinkResultInterface::class);
+        $modifiedLinkResult = self::createStub(LinkResultInterface::class);
         $linkResult->expects(self::once())
             ->method('withAttribute')
             ->with('href', '/en')
@@ -36,7 +36,7 @@ class DeSlashingPageLinkBuilderTest extends TestCase
 
         $event = new AfterLinkIsGeneratedEvent(
             $linkResult,
-            $this->createStub(ContentObjectRenderer::class),
+            self::createStub(ContentObjectRenderer::class),
             []
         );
 
@@ -54,12 +54,12 @@ class DeSlashingPageLinkBuilderTest extends TestCase
 
     public function testInvokeDoesNothingForHomepageRoot(): void
     {
-        $linkResult = $this->createStub(LinkResultInterface::class);
+        $linkResult = self::createStub(LinkResultInterface::class);
         $linkResult->method('getUrl')->willReturn('/');
 
         $event = new AfterLinkIsGeneratedEvent(
             $linkResult,
-            $this->createStub(ContentObjectRenderer::class),
+            self::createStub(ContentObjectRenderer::class),
             []
         );
 
@@ -75,13 +75,13 @@ class DeSlashingPageLinkBuilderTest extends TestCase
 
     public function testInvokeDoesNothingForNonPageLinks(): void
     {
-        $linkResult = $this->createStub(LinkResultInterface::class);
+        $linkResult = self::createStub(LinkResultInterface::class);
         $linkResult->method('getUrl')->willReturn('/some-file.pdf');
         $linkResult->method('getType')->willReturn('file');
 
         $event = new AfterLinkIsGeneratedEvent(
             $linkResult,
-            $this->createStub(ContentObjectRenderer::class),
+            self::createStub(ContentObjectRenderer::class),
             []
         );
 

--- a/Tests/Unit/DeSlashingPageLinkBuilderTest.php
+++ b/Tests/Unit/DeSlashingPageLinkBuilderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "de_slash" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\DeSlash\Tests\Unit;
+
+use B13\DeSlash\DeSlashingPageLinkBuilder;
+use B13\DeSlash\Service\UriCleaner;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Event\AfterLinkIsGeneratedEvent;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+
+class DeSlashingPageLinkBuilderTest extends TestCase
+{
+    public function testInvokeCleansLinkWhenTypeIsPageAndTrailingSlashIsPresent(): void
+    {
+        $linkResult = $this->createMock(LinkResultInterface::class);
+        $linkResult->method('getUrl')->willReturn('/en/');
+        $linkResult->method('getType')->willReturn(LinkService::TYPE_PAGE);
+
+        $modifiedLinkResult = $this->createStub(LinkResultInterface::class);
+        $linkResult->expects(self::once())
+            ->method('withAttribute')
+            ->with('href', '/en')
+            ->willReturn($modifiedLinkResult);
+
+        $event = new AfterLinkIsGeneratedEvent(
+            $linkResult,
+            $this->createStub(ContentObjectRenderer::class),
+            []
+        );
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::once())
+            ->method('removeTrailingSlashFromPath')
+            ->with('/en/')
+            ->willReturn('/en');
+
+        $listener = new DeSlashingPageLinkBuilder($uriCleaner);
+        $listener($event);
+
+        self::assertSame($modifiedLinkResult, $event->getLinkResult());
+    }
+
+    public function testInvokeDoesNothingForHomepageRoot(): void
+    {
+        $linkResult = $this->createStub(LinkResultInterface::class);
+        $linkResult->method('getUrl')->willReturn('/');
+
+        $event = new AfterLinkIsGeneratedEvent(
+            $linkResult,
+            $this->createStub(ContentObjectRenderer::class),
+            []
+        );
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::never())
+            ->method('removeTrailingSlashFromPath');
+
+        $listener = new DeSlashingPageLinkBuilder($uriCleaner);
+        $listener($event);
+
+        self::assertSame($linkResult, $event->getLinkResult());
+    }
+
+    public function testInvokeDoesNothingForNonPageLinks(): void
+    {
+        $linkResult = $this->createStub(LinkResultInterface::class);
+        $linkResult->method('getUrl')->willReturn('/some-file.pdf');
+        $linkResult->method('getType')->willReturn('file');
+
+        $event = new AfterLinkIsGeneratedEvent(
+            $linkResult,
+            $this->createStub(ContentObjectRenderer::class),
+            []
+        );
+
+        $uriCleaner = $this->createMock(UriCleaner::class);
+        $uriCleaner->expects(self::never())
+            ->method('removeTrailingSlashFromPath');
+
+        $listener = new DeSlashingPageLinkBuilder($uriCleaner);
+        $listener($event);
+
+        self::assertSame($linkResult, $event->getLinkResult());
+    }
+}

--- a/Tests/Unit/Service/UriCleanerTest.php
+++ b/Tests/Unit/Service/UriCleanerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "de_slash" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\DeSlash\Tests\Unit\Service;
+
+use B13\DeSlash\Service\UriCleaner;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class UriCleanerTest extends TestCase
+{
+    #[DataProvider('removeTrailingSlashFromPathDataProvider')]
+    public function testRemoveTrailingSlashFromPath(string $url, string $expected): void
+    {
+        $uriCleaner = new UriCleaner();
+        self::assertSame($expected, $uriCleaner->removeTrailingSlashFromPath($url));
+    }
+
+    public static function removeTrailingSlashFromPathDataProvider(): array
+    {
+        return [
+            'empty path / homepage root' => [
+                '/',
+                '/',
+            ],
+            'standard path with trailing slash' => [
+                '/en/',
+                '/en',
+            ],
+            'standard path without trailing slash' => [
+                '/en',
+                '/en',
+            ],
+            'path with trailing slash and query parameters' => [
+                '/en/?sitemap=pages&type=123',
+                '/en?sitemap=pages&type=123',
+            ],
+            'path without trailing slash and query parameters' => [
+                '/en?sitemap=pages&type=123',
+                '/en?sitemap=pages&type=123',
+            ],
+            'path with trailing slash, query parameters and fragment' => [
+                '/en/?sitemap=pages#anchor',
+                '/en?sitemap=pages#anchor',
+            ],
+            'full url with trailing slash' => [
+                'https://example.com/en/',
+                'https://example.com/en',
+            ],
+            'full url with trailing slash and query' => [
+                'https://example.com/en/?sitemap=pages&type=123',
+                'https://example.com/en?sitemap=pages&type=123',
+            ],
+            'full url with trailing slash and fragment' => [
+                'https://example.com/en/#anchor',
+                'https://example.com/en#anchor',
+            ],
+            'full url with trailing slash, port, query and fragment' => [
+                'https://example.com:8080/en/?sitemap=pages&type=123#anchor',
+                'https://example.com:8080/en?sitemap=pages&type=123#anchor',
+            ],
+            'empty string' => [
+                '',
+                '',
+            ],
+            'protocol-relative url with trailing slash' => [
+                '//example.com/en/',
+                '//example.com/en',
+            ],
+            'url with user and password' => [
+                'http://user:pass@example.com/en/',
+                'http://user:pass@example.com/en',
+            ],
+            'multiple trailing slashes' => [
+                '/en//',
+                '/en',
+            ],
+            'only slashes as path' => [
+                '///',
+                '///',
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords": ["seo", "typo3", "trailing slash"],
 	"license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms-core": "^12.4 || ^13.4"
+        "typo3/cms-core": "^13.4 || ^14.0"
     },
     "suggest": {
         "typo3/cms-seo": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,7 +21,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.0.0-13.4.99',
+            'typo3' => '13.4.0-14.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
### Background / Problem

The extension used a simple suffix check to determine if a URL needed to be de-slashed:
     `str_ends_with($linkResult->getUrl(), '/')`

  This check failed for any URLs containing query parameters or fragment identifiers.

  #### Example:

  For the URL:
   https://my-site.ddev.site/en/?sitemap=pages&type=1533906435

  • The Issue: Because the URL ends with the query parameter value ( f ) instead of a slash ( / ), the
  str_ends_with()  check returned  false .
  • The Consequence: The trailing slash after the  /en/  segment was never stripped, leaving the URL in an
  inconsistent state ( /en/?...  instead of  /en?... ).


  ### Solution

  This PR resolves issues with trailing slash removal on URLs that contain query parameters, fragments, or user
  credentials. It also refactors the de-slashing logic into a centralized utility class prevent code duplication.

  #### What is achieved:

  1. Query Parameter & Fragment Support:
  URLs like  /en/?sitemap=pages  or  /en/#anchor are now correctly de-slashed to  /en?sitemap=pages  and  /en#anchor 
  (previously they were skipped because the overall URL string did not end with  / ).
  2. Centralized Logic ( UriUtility ):
  Extracted the URL parsing and reconstruction logic to a reusable helper class:
  UriUtility::removeTrailingSlashFromPath() . This logic is now shared across:
      •  DeSlashCanonicalUrl 
      •  DeSlashHrefLangGenerator 
      •  DeSlashingPageLinkBuilder 
  3. Robust URL Reconstruction & Edge-Case Handling:
      • Credentials Preservation: Correctly retains user/password credentials (e.g.  user:pass@host ) if present in
      the URL.
      • Protocol-Relative URLs: Preserves leading double slashes (e.g.,  //example.com/en/  ->  //example.com/en ).
      • Preventing Redirect Chains: Uses  rtrim  to clean up multiple trailing slashes at once (e.g.,  /en//  ->  /en), preventing unnecessary double redirects (like  /en//  ->  /en/  ->  /en ).
      • Slash-Only Paths Guard: Ensures slash-only paths (like  /  or  /// ) remain unaffected and are preserved as-is.
      • Empty Strings: Handled safely via a dedicated guard clause.
  5. Test Coverage:
      • Introduced a PHPUnit test suite covering 15 distinct edge cases for URL de-slashing.
      • Verified that all functional tests (checking routing and 301 redirects) are passing successfully as well.